### PR TITLE
Add EmptyFdsetError type and handle unclean fdset dir better

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,9 @@ docs:
 	mandoc -Thtml pqrs.1 >docs/index.html
 
 lint:
-	cargo fmt -- --write-mode=diff
-	-cargo clippy
+	rustup default stable && cargo fmt -- --write-mode=diff
+	rustup default nightly && cargo clippy
+	rustup default stable
 
 package: build
 	cd target/$(TARGET)/debug;\

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
     1. [Download](#download)
 4. [Dependencies](#dependencies)
 5. [Tests](#tests)
+    1. [Linting](#linting)
 6. [Goals](#goals)
 7. [Todo](#todo)
 
@@ -106,6 +107,10 @@ protobuf = "1.2.1"
 ### Tests
 
 The testing tools are [./py-test](./py-test) for a Python random compiled protobuf generator ([py-test README](./py-test/README.md)), and [./tests](./tests) for Rust integration tests. The integration tests invoke the `pqrs` binary using `std::process` and checks return codes, stdout, etc. - inspired by [the xsv test suite](https://github.com/BurntSushi/xsv/tree/master/tests).
+
+#### Linting
+
+There is no linting in the Travis-CI job because it takes too long, but there is a make target (`make lint`). This is a bit hacky - it switches to rust-stable to run `cargo fmt`, rust-nightly to run `cargo clippy` (and then back to rust-stable). Run this before submitting a PR, or alternatively, run `cargo fmt` and `cargo clippy` however you prefer.
 
 ### Goals
 

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -1,0 +1,75 @@
+use error::PqrsError;
+use std::env;
+use std::fs::{File, read_dir};
+use std::path::PathBuf;
+use std::result::Result;
+use serde_protobuf::descriptor::{Descriptors, MessageDescriptor};
+use protobuf::parse_from_reader;
+
+pub struct LoadedDescriptors {
+    pub descriptors: Descriptors,
+    pub message_descriptors: Vec<MessageDescriptor>,
+}
+
+pub fn discover_fdsets(fdsetpath: Option<String>) -> Result<Vec<PathBuf>, PqrsError> {
+    let mut fdset_files = Vec::new();
+
+    let path = match fdsetpath {
+        Some(x) => PathBuf::from(x),
+        None => {
+            let mut home = match env::home_dir() {
+                Some(x) => x,
+                None => return Err(PqrsError::InitError(String::from("Could not find $HOME"))),
+            };
+            home.push(".pq");
+            home
+        }
+    };
+
+    for p in read_dir(path.as_path()).unwrap() {
+        let path = p.unwrap().path();
+        if !path.is_dir() {
+            fdset_files.push(path);
+        }
+    }
+    if fdset_files.is_empty() {
+        return Err(PqrsError::EmptyFdsetError(String::from("no files in fdset dir")));
+    }
+    Ok(fdset_files)
+}
+
+pub fn load_descriptors(fdsets: Vec<PathBuf>,
+                    with_message_descriptors: bool)
+                    -> Result<LoadedDescriptors, PqrsError> {
+    let mut descriptors = Descriptors::new();
+    let mut message_descriptors = Vec::new();
+
+    let mut fdset_proto_load_ctr = 0;
+    for fdset_path in fdsets {
+        let mut fdset_file = File::open(fdset_path.as_path()).unwrap();
+        let fdset_proto = match parse_from_reader(&mut fdset_file) {
+            Err(_) => continue,
+            Ok(x) => x,
+        };
+        fdset_proto_load_ctr += 1;
+        descriptors.add_file_set_proto(&fdset_proto);
+        if with_message_descriptors {
+            for file_proto in fdset_proto.get_file().iter() {
+                for message_proto in file_proto.get_message_type().iter() {
+                    message_descriptors
+                        .push(MessageDescriptor::from_proto(&fdset_path
+                                                                 .to_string_lossy()
+                                                                 .into_owned()
+                                                                 .as_str(),
+                                                            message_proto));
+                }
+            }
+        }
+    }
+
+    if fdset_proto_load_ctr == 0 {
+        return Err(PqrsError::EmptyFdsetError(String::from("no valid fdsets found")));
+    }
+    descriptors.resolve_refs();
+    Ok(LoadedDescriptors { descriptors: descriptors, message_descriptors: message_descriptors })
+}

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -39,8 +39,8 @@ pub fn discover_fdsets(fdsetpath: Option<String>) -> Result<Vec<PathBuf>, PqrsEr
 }
 
 pub fn load_descriptors(fdsets: Vec<PathBuf>,
-                    with_message_descriptors: bool)
-                    -> Result<LoadedDescriptors, PqrsError> {
+                        with_message_descriptors: bool)
+                        -> Result<LoadedDescriptors, PqrsError> {
     let mut descriptors = Descriptors::new();
     let mut message_descriptors = Vec::new();
 
@@ -57,10 +57,10 @@ pub fn load_descriptors(fdsets: Vec<PathBuf>,
             for file_proto in fdset_proto.get_file().iter() {
                 for message_proto in file_proto.get_message_type().iter() {
                     message_descriptors
-                        .push(MessageDescriptor::from_proto(&fdset_path
-                                                                 .to_string_lossy()
-                                                                 .into_owned()
-                                                                 .as_str(),
+                        .push(MessageDescriptor::from_proto(fdset_path
+                                                                .to_string_lossy()
+                                                                .into_owned()
+                                                                .as_str(),
                                                             message_proto));
                 }
             }
@@ -71,5 +71,8 @@ pub fn load_descriptors(fdsets: Vec<PathBuf>,
         return Err(PqrsError::EmptyFdsetError(String::from("no valid fdsets found")));
     }
     descriptors.resolve_refs();
-    Ok(LoadedDescriptors { descriptors: descriptors, message_descriptors: message_descriptors })
+    Ok(LoadedDescriptors {
+           descriptors: descriptors,
+           message_descriptors: message_descriptors,
+       })
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,6 @@
 #[derive(Debug)]
 pub enum PqrsError {
+    EmptyFdsetError(String),
     InitError(String),
     EofError(String),
     SerdeError(String),

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,11 +97,11 @@ fn main() {
         Err(PqrsError::InitError(msg)) => {
             writeln!(&mut stderr, "Could not find fdsets: {}", msg).unwrap();
             process::exit(-1);
-        },
+        }
         Err(PqrsError::EmptyFdsetError(msg)) => {
             writeln!(&mut stderr, "Could not find fdsets: {}", msg).unwrap();
             process::exit(-1);
-        },
+        }
         Err(e) => panic!(e),
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,15 +10,15 @@ extern crate serde_json;
 
 mod protob;
 mod error;
+mod discovery;
 
+use discovery::discover_fdsets;
 use docopt::Docopt;
 use protob::{named_message, guess_message};
 use error::PqrsError;
 use std::boxed::Box;
-use std::env;
-use std::fs::{File, read_dir};
+use std::fs::File;
 use std::io::{self, BufWriter, Write, BufReader, Read};
-use std::path::PathBuf;
 use std::process;
 
 const USAGE: &'static str = "
@@ -97,7 +97,11 @@ fn main() {
         Err(PqrsError::InitError(msg)) => {
             writeln!(&mut stderr, "Could not find fdsets: {}", msg).unwrap();
             process::exit(-1);
-        }
+        },
+        Err(PqrsError::EmptyFdsetError(msg)) => {
+            writeln!(&mut stderr, "Could not find fdsets: {}", msg).unwrap();
+            process::exit(-1);
+        },
         Err(e) => panic!(e),
     };
 
@@ -105,23 +109,4 @@ fn main() {
         Some(x) => named_message(&buf, &x, &mut outfile, fdsets).unwrap(),
         None => guess_message(&buf, &mut outfile, fdsets).unwrap(),
     }
-}
-
-fn discover_fdsets(fdsetpath: Option<String>) -> Result<Vec<PathBuf>, PqrsError> {
-    let path = match fdsetpath {
-        Some(x) => PathBuf::from(x),
-        None => {
-            let mut home = match env::home_dir() {
-                Some(x) => x,
-                None => return Err(PqrsError::InitError(String::from("Could not find $HOME"))),
-            };
-            home.push(".pq");
-            home
-        }
-    };
-
-    Ok(read_dir(path.as_path())
-           .unwrap()
-           .map(|x| x.unwrap().path())
-           .collect::<Vec<_>>())
 }

--- a/src/protob.rs
+++ b/src/protob.rs
@@ -30,8 +30,8 @@ pub fn named_message(data: &[u8],
     };
 
     let stream = CodedInputStream::from_bytes(data);
-    let mut deserializer = Deserializer::for_named_message(&loaded_descs.descriptors, &loc_msg_type, stream)
-        .unwrap();
+    let mut deserializer =
+        Deserializer::for_named_message(&loaded_descs.descriptors, &loc_msg_type, stream).unwrap();
     let mut serializer = Serializer::new(out);
     match deser(&mut deserializer) {
         Ok(value) => value.serialize(&mut serializer).unwrap(),
@@ -77,13 +77,13 @@ pub fn guess_message(data: &[u8], out: &mut Write, fdsets: Vec<PathBuf>) -> Resu
 
 fn deser(deserializer: &mut Deserializer) -> Result<Value, PqrsError> {
     match Value::deserialize(deserializer) {
-        Ok(x) => return Ok(x),
+        Ok(x) => Ok(x),
         Err(Error(ErrorKind::Protobuf(ProtobufError::WireError(msg)), _)) => {
             if msg == "unexpected EOF" {
                 return Err(PqrsError::EofError(msg));
             }
-            return Err(PqrsError::ProtobufError(msg));
+            Err(PqrsError::ProtobufError(msg))
         }
-        Err(e) => return Err(PqrsError::SerdeError(String::from(e.description()))),
-    };
+        Err(e) => Err(PqrsError::SerdeError(String::from(e.description()))),
+    }
 }


### PR DESCRIPTION
This handles the situation where having directories or invalid fdset files in your `~/.pq` or `--fdsets=<path>` fdsets path breaks the tool. Now I just discard anything which isn't a valid fdset (and return a `PqrsError::EmptyFdsetError` if nothing is found).